### PR TITLE
Modify the preview image of medium size and large size

### DIFF
--- a/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
+++ b/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
@@ -2955,7 +2955,7 @@
 
 .video-tile-view:lg > .content-box > .flip-view .front-box .custom-image-view {
     -fx-fit-width: 415px;
-    -fx-fit-height: 233px;
+    -fx-fit-height: 312px;
 }
 
 .video-tile-view:lg > .content-box > .flip-view .front-box .image-container {
@@ -2982,7 +2982,7 @@
 
 .video-tile-view:md > .content-box > .flip-view .front-box .custom-image-view {
     -fx-fit-width: 223px;
-    -fx-fit-height: 125px;
+    -fx-fit-height: 175px;
 }
 
 .video-tile-view:md > .content-box > .flip-view .front-box .image-container {
@@ -3011,7 +3011,7 @@
 }
 
 .video-tile-view:sm > .content-box > .flip-view .front-box .custom-image-view {
-    -fx-fit-width: 140px;
+    -fx-fit-width: 317px;
     -fx-fit-height: 78px;
 }
 


### PR DESCRIPTION
Modify the preview image of medium size and large size, the width fills the entire VideoTileView;
I suggest we keep the current design for the small size. Considering that the high-quality preview image returned by YouTube is 480*360, where the height is 0.75 times the width; if we make the small preview image match the width, then the height of the VideoTile would almost be completely occupied.

