### PR TITLE
fix HamburgerMenu setOnAction with onActionProperty 

### DIFF
--- a/components/src/main/java/com/dlsc/jfxcentral2/components/hamburger/HamburgerMenuView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/hamburger/HamburgerMenuView.java
@@ -87,6 +87,7 @@ public class HamburgerMenuView extends PaneBase {
 
             menuButton.setGraphic(buttonGraphic);
             menuButton.selectedProperty().bindBidirectional(menu.expandedProperty());
+            menuButton.onActionProperty().bind(menu.onActionProperty());
             menuButton.setMaxWidth(Double.MAX_VALUE);
 
             VBox submenuBox = new VBox();
@@ -122,11 +123,7 @@ public class HamburgerMenuView extends PaneBase {
             return icon;
         }, item.ikonProperty()));
         if (itemButton instanceof ButtonBase btn) {
-            btn.setOnAction(event -> {
-                if (item.getOnAction() != null) {
-                    item.getOnAction().handle(event);
-                }
-            });
+            btn.onActionProperty().bind(item.onActionProperty());
         }
         itemButton.setMaxWidth(Double.MAX_VALUE);
 


### PR DESCRIPTION
The MenuButton has replaced the previous setOnAction method with the current onActionProperty binding approach.