### PR TITLE
Enhancement tool detail header

### DIFF
--- a/components/src/main/java/com/dlsc/jfxcentral2/components/headers/SimpleDetailHeader.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/headers/SimpleDetailHeader.java
@@ -66,6 +66,7 @@ public class SimpleDetailHeader<T extends ModelObject> extends DetailHeader<T> {
         Label nameLabel = new Label(model.getName());
         nameLabel.getStyleClass().add("name");
         nameLabel.setWrapText(true);
+        nameLabel.textAlignmentProperty().bind(Bindings.when(needAdjustmentToLeft).then(TextAlignment.LEFT).otherwise(TextAlignment.CENTER));
 
         Label descriptionLabel = new Label();
         descriptionLabel.visibleProperty().bind(descriptionLabel.textProperty().isNotEmpty());
@@ -73,7 +74,7 @@ public class SimpleDetailHeader<T extends ModelObject> extends DetailHeader<T> {
         descriptionLabel.textProperty().bind(descriptionProperty());
         descriptionLabel.getStyleClass().add("description");
         descriptionLabel.setWrapText(true);
-        descriptionLabel.textAlignmentProperty().bind(Bindings.when(needAdjustmentToLeft).then(TextAlignment.LEFT).otherwise(TextAlignment.CENTER));
+        descriptionLabel.textAlignmentProperty().bind(nameLabel.textAlignmentProperty());
 
         SaveAndLikeButton saveAndLikeButton = new SaveAndLikeButton();
         saveAndLikeButton.setSaveButtonSelected(SaveAndLikeUtil.isSaved(model));

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/headers/ToolDetailHeader.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/headers/ToolDetailHeader.java
@@ -1,5 +1,6 @@
 package com.dlsc.jfxcentral2.components.headers;
 
+import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Tool;
 import org.apache.commons.lang3.StringUtils;
 
@@ -9,6 +10,6 @@ public class ToolDetailHeader extends SimpleDetailHeader<Tool>  {
         super(tool);
         getStyleClass().add("tool-detail-header");
         setWebsite(StringUtils.isNotBlank(getModel().getHomepage()) ? getModel().getHomepage() : getModel().getRepository());
-        //imageProperty().bind(ImageManager.getInstance().toolImageProperty(tool));
+        imageProperty().bind(ImageManager.getInstance().toolImageProperty(tool));
     }
 }


### PR DESCRIPTION
Adjust the alignment according to the presence or absence of image #170 

- When the screen is small, the element is always centered.
<img src="https://github.com/dlemmermann/jfxcentral2/assets/75261429/c931da1f-f183-48fc-b89c-5c05d0fd5468" width="30%">

- When a logo icon exists, the text node is aligned to the left.
<img src="https://github.com/dlemmermann/jfxcentral2/assets/75261429/79b8bd7f-bd2e-49f8-8285-74155906d3d5" width="40%">

- When there's no logo icon, the text node is centered.
<img src="https://github.com/dlemmermann/jfxcentral2/assets/75261429/254c4eb9-e577-42af-91f7-f2111ca799ce" width="40%">
