### PR TITLE
Fixed: Large Gaps in Library Preview Pane on Desktop Client

### DIFF
--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -64,6 +64,7 @@ public class PacksIconsView extends PaneBase {
 
         // top
         searchField = new SearchTextField();
+        searchField.setFocusTraversable(false);
         searchField.textProperty().addListener((ob, ov, str) -> {
             if (future != null) {
                 future.cancel(false);

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/SimpleTileView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/SimpleTileView.java
@@ -57,6 +57,7 @@ public class SimpleTileView<T extends ModelObject> extends TileViewBase<T> {
         avatarView.typeProperty().bind(avatarTypeProperty());
         avatarView.visibleProperty().bind(avatarView.imageProperty().isNotNull());
         avatarView.managedProperty().bind(avatarView.imageProperty().isNotNull());
+        avatarView.setMouseTransparent(true);
 
         Label nameLabel = new Label();
         nameLabel.getStyleClass().add("title");
@@ -69,6 +70,7 @@ public class SimpleTileView<T extends ModelObject> extends TileViewBase<T> {
         detailButton.getStyleClass().add("detail-button");
         detailButton.setGraphic(new FontIcon(IkonUtil.link));
         detailButton.setFocusTraversable(false);
+        LinkUtil.setLink(detailButton, PageUtil.getLink(item));
 
         badgeBox.getStyleClass().add("badge-box");
 

--- a/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
+++ b/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
@@ -1415,7 +1415,7 @@
     -fx-pref-height: 225px;
     -fx-max-width: 303px;
     -fx-max-height: 225px;
-    -fx-hgap: 10px;
+    -fx-hgap: 8px;
     -fx-vgap: 15px;
 }
 
@@ -5728,7 +5728,7 @@
 }
 
 .library-preview-box:lg .previews-pane {
-    -fx-hgap: 12px;
+    -fx-hgap: 11px;
     -fx-vgap: 10px;
     -fx-padding: 0 0 0 5px;
 }


### PR DESCRIPTION
1. #413 
2. #411 
3. #410 
4. #409 