### PR TITLE
fix: layout white space in GradientDesigner and Markdown

### DIFF
--- a/components/src/main/java/com/dlsc/jfxcentral2/utilities/paintpicker/impl/NamedColorsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utilities/paintpicker/impl/NamedColorsView.java
@@ -20,6 +20,7 @@ public class NamedColorsView extends VBox {
         Label title = new Label("Named Colors");
         TilePane tilePane = new TilePane();
         tilePane.getStyleClass().add("tile-pane");
+        tilePane.setPrefColumns(15);
         for (NamedColor namedColor : namedColors) {
             Rectangle rectangle = new Rectangle(18, 18);
             rectangle.setUserData(namedColor);
@@ -48,20 +49,20 @@ public class NamedColorsView extends VBox {
                 return;
             }
 
-            if (result.startsWith("#")){
+            if (result.startsWith("#")) {
                 tilePane.getChildren().forEach(node -> {
                     Rectangle rectangle = (Rectangle) node;
-                    rectangle.setVisible(StringUtils.containsIgnoreCase(((NamedColor)rectangle.getUserData()).hex(), result));
+                    rectangle.setVisible(StringUtils.containsIgnoreCase(((NamedColor) rectangle.getUserData()).hex(), result));
                 });
-            }else {
+            } else {
                 tilePane.getChildren().forEach(node -> {
                     Rectangle rectangle = (Rectangle) node;
-                    rectangle.setVisible(StringUtils.containsIgnoreCase(((NamedColor)rectangle.getUserData()).name(), result));
+                    rectangle.setVisible(StringUtils.containsIgnoreCase(((NamedColor) rectangle.getUserData()).name(), result));
                 });
             }
         });
 
-        HBox topBox = new HBox(title,searchField);
+        HBox topBox = new HBox(title, searchField);
         topBox.getStyleClass().add("top-box");
         getChildren().addAll(topBox, tilePane);
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <junit.version>5.10.0</junit.version>
         <ikonli.version>12.3.1</ikonli.version>
         <jpro.version>2025.3.0</jpro.version>
-        <jpro.platform.version>0.5.7</jpro.platform.version>
+        <jpro.platform.version>0.5.8</jpro.platform.version>
         <batik.version>1.16</batik.version>
         <attach.version>4.0.19</attach.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
### GradientDesignerView
Fixed an issue where the NamedColorsView's TilePane calculated an incorrect preferred height due to the default prefColumns value, causing a large blank area at the bottom of the layout.

### Markdown Component
Upgraded the jpro-platform dependency to the latest version to fix incorrect list item height calculation.