### PR TITLE
Merge ikonli icon packs by artifactId and add ikonli 12.4 new packs

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -150,6 +150,11 @@
 
         <dependency>
             <groupId>org.kordamp.ikonli</groupId>
+            <artifactId>ikonli-bytedance-pack</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kordamp.ikonli</groupId>
             <artifactId>ikonli-captainicon-pack</artifactId>
         </dependency>
 
@@ -216,6 +221,11 @@
         <dependency>
             <groupId>org.kordamp.ikonli</groupId>
             <artifactId>ikonli-fontawesome5-pack</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kordamp.ikonli</groupId>
+            <artifactId>ikonli-fontawesome6-pack</artifactId>
         </dependency>
 
         <dependency>

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
@@ -387,20 +387,39 @@ public class JFXCentral2App extends Application {
             String[] parts = StringUtils.split(requestPath, '/');
             // Route to IconsCategoryPage or IconPackDetailPage: /icons or /icons/{ikonPackId}
             if (parts.length < 3) {
-                return createResponse(r, IkonliPack.class, () -> new IconsCategoryPage(size), id -> new IconPackDetailPage(size, id));
+                int index = requestPath.lastIndexOf("/");
+                if (index > 0) {
+                    String id = requestPath.substring(index + 1).trim();
+                    // Check both DataRepository (legacy ids) and aggregated packs
+                    if (!DataRepository.getInstance().isValidId(IkonliPack.class, id)
+                            && IkonliPackUtil.getInstance().getAggregatedPack(id) == null) {
+                        return Response.view(new ErrorPage(size, r));
+                    }
+                    return Response.view(new IconPackDetailPage(size, id));
+                }
+                return Response.view(new IconsCategoryPage(size));
             }
 
             //  Route to SingleIconPage: /icons/{ikonliPackId}/{iconDescription}
             String ikonliPackId = parts[1];
             String iconDescription = parts[2];
 
-            return DataRepository.getInstance().getIkonliPackById(ikonliPackId)
-                    .flatMap(ikonliPack -> IkonliPackUtil.getInstance().getIkon(ikonliPack, iconDescription)
-                            .map(ikon -> {
-                                IconInfo iconInfo = new IconInfoBuilder(ikon, ikonliPack.getName(), ikonliPackId).build();
-                                return Response.view(new SingleIconPage(size, iconInfo, true));
-                            }))
-                    .orElseGet(() -> Response.view(new ErrorPage(size, r)));
+            // Try aggregated pack first, then fall back to DataRepository
+            IkonliPack pack = IkonliPackUtil.getInstance().getAggregatedPack(ikonliPackId);
+            if (pack == null) {
+                pack = DataRepository.getInstance().getIkonliPackById(ikonliPackId).orElse(null);
+            }
+
+            if (pack != null) {
+                final IkonliPack finalPack = pack;
+                return IkonliPackUtil.getInstance().getIkon(finalPack, iconDescription)
+                        .map(ikon -> {
+                            IconInfo iconInfo = new IconInfoBuilder(ikon, finalPack.getName(), ikonliPackId).build();
+                            return Response.view(new SingleIconPage(size, iconInfo, true));
+                        })
+                        .orElseGet(() -> Response.view(new ErrorPage(size, r)));
+            }
+            return Response.view(new ErrorPage(size, r));
         };
     }
 

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/TrayIconManager.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/TrayIconManager.java
@@ -3,6 +3,7 @@ package com.dlsc.jfxcentral2.app;
 import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Documentation;
 import com.dlsc.jfxcentral.data.model.ModelObject;
+import com.dlsc.jfxcentral2.utils.IkonliPackUtil;
 import com.dlsc.jfxcentral2.utils.LOGGER;
 import com.dlsc.jfxcentral2.utils.OSUtil;
 import com.dlsc.jfxcentral2.utils.PageUtil;
@@ -88,7 +89,7 @@ public class TrayIconManager {
         repository.getBooks().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(books, mo));
         repository.getRealWorldApps().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(realWorld, mo));
         repository.getTips().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(tips, mo));
-        repository.getIkonliPacks().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(icons, mo));
+        IkonliPackUtil.getInstance().getAggregatedPacks().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(icons, mo));
         repository.getUtilities().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(utilities, mo));
         repository.getDocumentation().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(documentation, mo, modelObject -> {
             String docUrl = null;

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/details/IconPackDetailPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/details/IconPackDetailPage.java
@@ -18,6 +18,14 @@ public class IconPackDetailPage extends DetailsPageBase<IkonliPack> {
 
     public IconPackDetailPage(ObjectProperty<Size> size, String itemId) {
         super(size, IkonliPack.class, itemId);
+
+        // Override: try aggregated pack lookup if DataRepository didn't find the item
+        if (getItem() == null) {
+            IkonliPack aggregated = IkonliPackUtil.getInstance().getAggregatedPack(itemId);
+            if (aggregated != null) {
+                setItem(aggregated);
+            }
+        }
     }
 
     @Override
@@ -32,7 +40,7 @@ public class IconPackDetailPage extends DetailsPageBase<IkonliPack> {
         IkonliIconsFilter filter = new IkonliIconsFilter();
         filter.sizeProperty().bind(sizeProperty());
 
-        // data
+        // data (supports both original and aggregated packs)
         FilteredList<Ikon> filteredList = new FilteredList<>(IkonliPackUtil.getInstance().getIkonList(ikonliPack));
         filteredList.predicateProperty().bind(filter.predicateProperty());
 

--- a/app/src/main/java/module-info.java
+++ b/app/src/main/java/module-info.java
@@ -34,6 +34,7 @@ open module com.dlsc.jfxcentral2.app {
     requires org.kordamp.ikonli.bootstrapicons;
     requires org.kordamp.ikonli.boxicons;
     requires org.kordamp.ikonli.bpmn;
+    requires org.kordamp.ikonli.bytedance;
     requires org.kordamp.ikonli.captainicon;
     requires org.kordamp.ikonli.carbonicons;
     requires org.kordamp.ikonli.codicons;
@@ -48,6 +49,7 @@ open module com.dlsc.jfxcentral2.app {
     requires org.kordamp.ikonli.fluentui;
     requires org.kordamp.ikonli.fontawesome;
     requires org.kordamp.ikonli.fontawesome5;
+    requires org.kordamp.ikonli.fontawesome6;
     requires org.kordamp.ikonli.fontelico;
     requires org.kordamp.ikonli.foundation;
     requires org.kordamp.ikonli.hawcons;

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -246,6 +246,10 @@
         </dependency>
         <dependency>
             <groupId>org.kordamp.ikonli</groupId>
+            <artifactId>ikonli-bytedance-pack</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kordamp.ikonli</groupId>
             <artifactId>ikonli-captainicon-pack</artifactId>
         </dependency>
         <dependency>
@@ -299,6 +303,10 @@
         <dependency>
             <groupId>org.kordamp.ikonli</groupId>
             <artifactId>ikonli-fontawesome5-pack</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kordamp.ikonli</groupId>
+            <artifactId>ikonli-fontawesome6-pack</artifactId>
         </dependency>
         <dependency>
             <groupId>org.kordamp.ikonli</groupId>

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/IconPreviewPane.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/IconPreviewPane.java
@@ -19,10 +19,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import org.kordamp.ikonli.Ikon;
-import org.kordamp.ikonli.IkonProvider;
 import org.kordamp.ikonli.javafx.FontIcon;
-
-import java.util.EnumSet;
 
 public class IconPreviewPane extends PaneBase {
 
@@ -77,10 +74,7 @@ public class IconPreviewPane extends PaneBase {
                             }
                         }
 
-                        ObservableList<? extends Ikon> icons = FXCollections.observableArrayList();
-                        IkonProvider ikonProvider = IkonliPackUtil.getInstance().getIkonData(ikonPackModel.getName()).getIkonProvider();
-                        EnumSet enumSet = EnumSet.allOf(ikonProvider.getIkon());
-                        icons.addAll(enumSet);
+                        ObservableList<Ikon> icons = IkonliPackUtil.getInstance().getIkonList(ikonPackModel);
                         FXCollections.shuffle(icons);
 
                         for (int i = 0; i < columnCount * 4 && i < icons.size(); i++) {

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -2,7 +2,6 @@ package com.dlsc.jfxcentral2.components;
 
 import com.dlsc.gemsfx.SelectionBox;
 import com.dlsc.gemsfx.util.SimpleStringConverter;
-import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.IkonliPack;
 import com.dlsc.jfxcentral2.components.gridview.IkonGridView;
 import com.dlsc.jfxcentral2.components.gridview.ModelGridView;
@@ -20,9 +19,6 @@ import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
-import javafx.scene.Group;
-import javafx.scene.Node;
-import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.SelectionMode;
@@ -38,10 +34,7 @@ import javafx.util.StringConverter;
 import org.apache.commons.lang3.StringUtils;
 import org.kordamp.ikonli.Ikon;
 
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
 
 public class PacksIconsView extends PaneBase {
 
@@ -221,8 +214,8 @@ public class PacksIconsView extends PaneBase {
         packGridView.setRows(3);
         packGridView.managedProperty().bind(visibleProperty());
 
-        // packs data
-        ObservableList<IkonliPack> packs = FXCollections.observableArrayList(DataRepository.getInstance().getIkonliPacks());
+        // packs data (aggregated: one entry per Maven artifact)
+        ObservableList<IkonliPack> packs = FXCollections.observableArrayList(IkonliPackUtil.getInstance().getAggregatedPacks());
         FilteredList<IkonliPack> filteredPacks = new FilteredList<>(packs);
         filteredPacks.predicateProperty().bind(Bindings.createObjectBinding(() -> {
             String text = searchText.get().trim();
@@ -348,7 +341,7 @@ public class PacksIconsView extends PaneBase {
     }
 
     private SelectionBox<IkonliPack> initIkonliPackSelection() {
-        ObservableList<IkonliPack> packs = FXCollections.observableArrayList(DataRepository.getInstance().getIkonliPacks());
+        ObservableList<IkonliPack> packs = FXCollections.observableArrayList(IkonliPackUtil.getInstance().getAggregatedPacks());
         SelectionBox<IkonliPack> selectionBox = new SelectionBox<>(packs);
         selectionBox.setPromptText("Select");
         selectionBox.setItemConverter(new SimpleStringConverter<>(IkonliPack::getName));
@@ -361,99 +354,10 @@ public class PacksIconsView extends PaneBase {
                 return String.valueOf(list.size());
             }
         }));
-        selectionBox.setTop(createExtraButtonsBox(selectionBox));
+
         selectionBox.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         selectionBox.getSelectionModel().selectAll();
         return selectionBox;
-    }
-
-    private Node createExtraButtonsBox(SelectionBox<IkonliPack> selectionBox) {
-        Button clearButton = selectionBox.createExtraButton("Clear", null);
-        clearButton.getStyleClass().add("clear-button");
-        clearButton.setOnAction(e -> selectionBox.getSelectionModel().clearSelection());
-
-        Button selectAllButton = selectionBox.createExtraButton("Select All", () -> selectionBox.getSelectionModel().selectAll());
-        selectAllButton.managedProperty().bind(selectAllButton.visibleProperty());
-        selectAllButton.visibleProperty().bind(selectionBox.currentSelectionModeProperty().isEqualTo(SelectionMode.MULTIPLE));
-        selectAllButton.getStyleClass().add("select-all-button");
-
-        Button materialDesignAZ = createSelectMaterialDesignAZButton(selectionBox);
-
-        Button material2Variants = createSelectMaterial2VariantsButton(selectionBox);
-
-        VBox actionBox = new VBox(clearButton, selectAllButton, material2Variants, materialDesignAZ);
-        actionBox.managedProperty().bind(actionBox.visibleProperty());
-        actionBox.visibleProperty().bind(selectionBox.itemsProperty().emptyProperty().not());
-
-        Label quickSelectLabel = new Label("QUICK SELECT");
-        quickSelectLabel.getStyleClass().add("quick-select-label");
-        quickSelectLabel.setRotate(-90);
-
-        HBox extraButtonsBox = new HBox(new Group(quickSelectLabel), actionBox);
-        extraButtonsBox.getStyleClass().add("extra-buttons-box");
-
-        return extraButtonsBox;
-    }
-
-    private Button createSelectMaterial2VariantsButton(SelectionBox<IkonliPack> selectionBox) {
-        return selectionBox.createExtraButton("Select Material2 Variants", () -> {
-            selectionBox.getSelectionModel().clearSelection();
-
-            List<IkonliPack> items = selectionBox.getItems();
-            List<Integer> indices = new ArrayList<>();
-
-            String prefix = "Material2";
-
-            for (int i = 0; i < items.size(); i++) {
-                IkonliPack pack = items.get(i);
-                String name = Objects.requireNonNullElse(pack.getName(), "");
-
-                if (name.startsWith(prefix)) {
-                    indices.add(i);
-                }
-            }
-
-            if (!indices.isEmpty()) {
-                selectionBox.getSelectionModel().selectIndices(
-                        indices.get(0),
-                        indices.size() > 1
-                                ? indices.subList(1, indices.size()).stream().mapToInt(Integer::intValue).toArray()
-                                : new int[0]
-                );
-            }
-        });
-    }
-
-    private Button createSelectMaterialDesignAZButton(SelectionBox<IkonliPack> selectionBox) {
-        return selectionBox.createExtraButton("Select MaterialDesign A–Z", () -> {
-            selectionBox.getSelectionModel().clearSelection();
-
-            List<IkonliPack> items = selectionBox.getItems();
-            List<Integer> indices = new ArrayList<>();
-
-            String prefix = "MaterialDesign";
-            int expectedLength = prefix.length() + 1;
-
-            for (int i = 0; i < items.size(); i++) {
-                IkonliPack pack = items.get(i);
-                String name = Objects.requireNonNullElse(pack.getName(), "");
-
-                if (name.startsWith(prefix)
-                        && name.length() == expectedLength
-                        && Character.isUpperCase(name.charAt(prefix.length()))) {
-                    indices.add(i);
-                }
-            }
-
-            if (!indices.isEmpty()) {
-                selectionBox.getSelectionModel().selectIndices(
-                        indices.get(0),
-                        indices.size() > 1
-                                ? indices.subList(1, indices.size()).stream().mapToInt(Integer::intValue).toArray()
-                                : new int[0]
-                );
-            }
-        });
     }
 
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/TopMenuBar.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/TopMenuBar.java
@@ -19,6 +19,7 @@ import com.dlsc.jfxcentral.data.model.Tutorial;
 import com.dlsc.jfxcentral.data.model.Video;
 import com.dlsc.jfxcentral2.iconfont.JFXCentralIcon;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
+import com.dlsc.jfxcentral2.utils.IkonliPackUtil;
 import com.dlsc.jfxcentral2.utils.ModelObjectTool;
 import com.dlsc.jfxcentral2.utils.OSUtil;
 import com.dlsc.jfxcentral2.utils.PagePath;
@@ -161,7 +162,7 @@ public class TopMenuBar extends PaneBase {
         search(repository.getDownloads(), pattern, results);
         search(repository.getTutorials(), pattern, results);
         search(repository.getTips(), pattern, results);
-        search(repository.getIkonliPacks(), pattern, results);
+        search(IkonliPackUtil.getInstance().getAggregatedPacks(), pattern, results);
 
         if (!OSUtil.isNative()) {
             search(repository.getUtilities(), pattern, results);

--- a/components/src/main/java/com/dlsc/jfxcentral2/model/IconInfoBuilder.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/model/IconInfoBuilder.java
@@ -25,19 +25,28 @@ public class IconInfoBuilder {
         IconInfo iconInfo = new IconInfo();
         iconInfo.setIkon(ikon);
 
-        // if the pack name is not provided, try to get it from the ikon
-        if (ikonliPackName == null) {
-            IkonliPack ikonliPack = IkonliPackUtil.getInstance().getIkonData(ikon).getIkonliPack();
-            if (ikonliPack != null) {
-                ikonliPackName = ikonliPack.getName();
+        // Resolve pack name and id from the aggregated pack
+        if (ikonliPackName == null || ikonliPackId == null) {
+            IkonData ikonData = IkonliPackUtil.getInstance().getIkonData(ikon);
+            if (ikonData != null) {
+                IkonliPack originalPack = ikonData.getIkonliPack();
+                if (originalPack != null) {
+                    String aggregatedId = IkonliPackUtil.getInstance().getAggregatedId(originalPack);
+                    if (aggregatedId != null) {
+                        IkonliPack aggregatedPack = IkonliPackUtil.getInstance().getAggregatedPack(aggregatedId);
+                        if (aggregatedPack != null) {
+                            if (ikonliPackName == null) {
+                                ikonliPackName = aggregatedPack.getName();
+                            }
+                            if (ikonliPackId == null) {
+                                ikonliPackId = aggregatedId;
+                            }
+                        }
+                    }
+                }
             }
         }
         iconInfo.setIkonliPackName(ikonliPackName);
-
-        // if the pack id is not provided, try to get it from the pack name
-        if (ikonliPackId == null && ikonliPackName != null) {
-            ikonliPackId = ikonliPackName.toLowerCase();
-        }
         iconInfo.setIkonliPackId(ikonliPackId);
 
         // set the icon description

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/IkonliPackUtil.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/IkonliPackUtil.java
@@ -2,7 +2,10 @@ package com.dlsc.jfxcentral2.utils;
 
 import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Dependency;
+import com.dlsc.jfxcentral.data.model.IconStyle;
 import com.dlsc.jfxcentral.data.model.IkonliPack;
+import com.dlsc.jfxcentral.data.model.Installing;
+import com.dlsc.jfxcentral.data.model.Maven;
 import com.dlsc.jfxcentral2.model.IkonData;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -10,27 +13,66 @@ import org.apache.commons.lang3.StringUtils;
 import org.kordamp.ikonli.Ikon;
 import org.kordamp.ikonli.IkonProvider;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 public class IkonliPackUtil {
 
+    // ==================== Constants ====================
+
+    private static final String ARTIFACT_PREFIX = "ikonli-";
+    private static final String ARTIFACT_SUFFIX = "-pack";
+
+    // ==================== Singleton ====================
+
     private static final IkonliPackUtil instance = new IkonliPackUtil();
+
+    // ==================== Internal Data Structures ====================
+
+    /**
+     * Maps each individual Ikon enum constant to its IkonData.
+     */
     private final Map<Ikon, IkonData> dataMap = new HashMap<>();
+
+    /**
+     * Maps enum class simple name to IkonData. Retained for internal compatibility.
+     * Note: FA5/FA6 share the same simple names, so the last registered wins.
+     * This is acceptable because dataMap is the authoritative lookup for individual icons.
+     */
     private final Map<String, IkonData> nameMap = new HashMap<>();
+
+    /**
+     * All discovered IkonData entries, sorted by name.
+     */
     private final Set<IkonData> ikonDataSet = new TreeSet<>();
+
+    /**
+     * Aggregated id (derived from artifactId) to aggregated IkonliPack instance.
+     * Each artifactId maps to exactly one aggregated IkonliPack for display.
+     */
+    private final Map<String, IkonliPack> aggregatedPackMap = new LinkedHashMap<>();
+
+    /**
+     * Aggregated id to the list of IkonData entries belonging to that artifact.
+     */
+    private final Map<String, List<IkonData>> groupedByArtifact = new LinkedHashMap<>();
+
     private Set<Ikon> allIkons;
 
+    // ==================== Constructor ====================
+
     private IkonliPackUtil() {
+        // Step 1: Discover all IkonProviders via ServiceLoader
         if (null != IkonProvider.class.getModule().getLayer()) {
             for (IkonProvider provider : ServiceLoader.load(IkonProvider.class.getModule().getLayer(), IkonProvider.class)) {
                 ikonDataSet.add(IkonData.of(provider));
@@ -40,56 +82,322 @@ public class IkonliPackUtil {
                 ikonDataSet.add(IkonData.of(provider));
             }
         }
+
+        // Step 2: Match IkonData to IkonliPack using name + module (fixes FA5/FA6 conflict)
         List<IkonliPack> ikonliPacks = DataRepository.getInstance().getIkonliPacks();
 
         ikonDataSet.forEach(data -> {
             for (IkonliPack pack : ikonliPacks) {
-                if (pack.getName().equals(data.getName())) {
+                if (pack.getName().equals(data.getName())
+                        && moduleMatches(data.getIkonProvider().getIkon().getPackageName(), pack.getModule())) {
                     data.setIkonliPack(pack);
                     break;
                 }
             }
             IkonProvider ikonProvider = data.getIkonProvider();
-            Class ikonProviderClass = ikonProvider.getIkon();
+            Class<?> ikonProviderClass = ikonProvider.getIkon();
             nameMap.put(ikonProviderClass.getSimpleName(), data);
-            EnumSet enumSet = EnumSet.allOf(ikonProviderClass);
+            EnumSet<?> enumSet = EnumSet.allOf(ikonProviderClass.asSubclass(Enum.class));
             enumSet.forEach(icon -> dataMap.put((Ikon) icon, data));
         });
+
+        // Step 3: Group by artifactId and create aggregated IkonliPack instances
+        buildAggregatedPacks();
     }
+
+    // ==================== Aggregation Logic ====================
+
+    private void buildAggregatedPacks() {
+        // Group IkonData by aggregated id (derived from artifactId)
+        for (IkonData data : ikonDataSet) {
+            IkonliPack originalPack = data.getIkonliPack();
+            if (originalPack == null) {
+                continue;
+            }
+            String aggregatedId = extractAggregatedId(originalPack);
+            if (aggregatedId == null) {
+                continue;
+            }
+            groupedByArtifact.computeIfAbsent(aggregatedId, k -> new ArrayList<>()).add(data);
+        }
+
+        // Create one aggregated IkonliPack per group
+        for (Map.Entry<String, List<IkonData>> entry : groupedByArtifact.entrySet()) {
+            String aggregatedId = entry.getKey();
+            List<IkonData> dataList = entry.getValue();
+            IkonliPack representative = dataList.get(0).getIkonliPack();
+
+            IkonliPack aggregated = new IkonliPack();
+            aggregated.setId(aggregatedId);
+            aggregated.setName(representative.getTitle());
+            aggregated.setTitle(representative.getTitle());
+            aggregated.setDescription(representative.getDescription());
+            aggregated.setModule(representative.getModule());
+            aggregated.setInstalling(representative.getInstalling());
+            aggregated.setUrl(representative.getUrl());
+            aggregated.setFontVersion(representative.getFontVersion());
+            aggregated.setCreatedOn(representative.getCreatedOn());
+            aggregated.setModifiedOn(representative.getModifiedOn());
+            aggregated.setIconStyle(resolveIconStyle(dataList));
+
+            aggregatedPackMap.put(aggregatedId, aggregated);
+        }
+    }
+
+    /**
+     * Derives the aggregated id from an IkonliPack's artifactId.
+     * Example: "ikonli-materialdesign2-pack" becomes "materialdesign2".
+     */
+    private String extractAggregatedId(IkonliPack pack) {
+        Installing installing = pack.getInstalling();
+        if (installing == null || installing.getMaven() == null || installing.getMaven().getDependency() == null) {
+            return null;
+        }
+        String artifactId = installing.getMaven().getDependency().getArtifactId();
+        if (artifactId == null) {
+            return null;
+        }
+        String id = artifactId;
+        if (id.startsWith(ARTIFACT_PREFIX)) {
+            id = id.substring(ARTIFACT_PREFIX.length());
+        }
+        if (id.endsWith(ARTIFACT_SUFFIX)) {
+            id = id.substring(0, id.length() - ARTIFACT_SUFFIX.length());
+        }
+        return id;
+    }
+
+    /**
+     * Resolves the iconStyle for an aggregated pack.
+     * If all sub-packs share the same style, use that; otherwise MIXING.
+     */
+    private IconStyle resolveIconStyle(List<IkonData> dataList) {
+        IconStyle first = null;
+        for (IkonData data : dataList) {
+            IkonliPack pack = data.getIkonliPack();
+            if (pack == null || pack.getIconStyle() == null) {
+                continue;
+            }
+            if (first == null) {
+                first = pack.getIconStyle();
+            } else if (first != pack.getIconStyle()) {
+                return IconStyle.MIXING;
+            }
+        }
+        return first != null ? first : IconStyle.MIXING;
+    }
+
+    /**
+     * Checks whether a Java package name matches a JSON module field value.
+     * Handles the case where the module field may be a short name (e.g., "materialdesign2")
+     * instead of the full package name (e.g., "org.kordamp.ikonli.materialdesign2").
+     */
+    private static boolean moduleMatches(String packageName, String module) {
+        if (packageName == null || module == null) {
+            return false;
+        }
+        return packageName.equals(module) || packageName.endsWith("." + module);
+    }
+
+    // ==================== Singleton Access ====================
 
     public static IkonliPackUtil getInstance() {
         return instance;
     }
 
+    // ==================== Individual Icon Lookup ====================
+
+    /**
+     * Gets the IkonData for a specific icon.
+     */
     public IkonData getIkonData(Ikon ikon) {
         return dataMap.get(ikon);
     }
 
-    public Set<IkonData> getIkonDataSet() {
-        return ikonDataSet;
-    }
-
-    public Map<Ikon, IkonData> getDataMap() {
-        return dataMap;
-    }
-
+    /**
+     * Gets the IkonData by enum class simple name.
+     * Note: For FA5/FA6 with same simple names, only the last registered is returned.
+     */
     public IkonData getIkonData(String simpleName) {
         return nameMap.get(simpleName);
     }
 
+    /**
+     * Gets all discovered IkonData entries.
+     */
+    public Set<IkonData> getIkonDataSet() {
+        return ikonDataSet;
+    }
+
+    /**
+     * Gets the raw data map (Ikon to IkonData).
+     */
+    public Map<Ikon, IkonData> getDataMap() {
+        return dataMap;
+    }
+
+    // ==================== Aggregated Pack Access ====================
+
+    /**
+     * Returns the list of aggregated IkonliPack instances for display.
+     * Each entry represents one Maven artifact (one dependency).
+     */
+    public List<IkonliPack> getAggregatedPacks() {
+        return new ArrayList<>(aggregatedPackMap.values());
+    }
+
+    /**
+     * Gets an aggregated IkonliPack by its aggregated id.
+     */
+    public IkonliPack getAggregatedPack(String aggregatedId) {
+        return aggregatedPackMap.get(aggregatedId);
+    }
+
+    /**
+     * Gets the aggregated id for a given IkonliPack.
+     * Works for both original and aggregated IkonliPack instances.
+     */
+    public String getAggregatedId(IkonliPack pack) {
+        // Check if this is already an aggregated pack
+        if (aggregatedPackMap.containsKey(pack.getId())) {
+            return pack.getId();
+        }
+        // Otherwise derive from artifactId
+        return extractAggregatedId(pack);
+    }
+
+    // ==================== Icon List Methods ====================
+
+    /**
+     * Gets all icons for a given IkonliPack. Supports both original and aggregated packs.
+     * For aggregated packs, returns the union of all sub-packs' icons.
+     */
     public ObservableList<Ikon> getIkonList(IkonliPack iconPack) {
-        IkonData ikonData = getIkonData(iconPack.getName());
-        IkonProvider ikonProvider = ikonData.getIkonProvider();
-        EnumSet enumSet = EnumSet.allOf(ikonProvider.getIkon());
-        ObservableList<Ikon> list = FXCollections.observableArrayList(enumSet);
-        for (Ikon ikon : list) {
-            IkonData tempData = getIkonData(ikon);
-            if (tempData != null && tempData.getIkonliPack() == null) {
-                tempData.setIkonliPack(iconPack);
+        String aggregatedId = getAggregatedId(iconPack);
+        List<IkonData> dataList = groupedByArtifact.get(aggregatedId);
+
+        if (dataList != null) {
+            ObservableList<Ikon> result = FXCollections.observableArrayList();
+            for (IkonData data : dataList) {
+                IkonProvider ikonProvider = data.getIkonProvider();
+                EnumSet<?> enumSet = EnumSet.allOf(ikonProvider.getIkon().asSubclass(Enum.class));
+                for (Object icon : enumSet) {
+                    Ikon ikon = (Ikon) icon;
+                    result.add(ikon);
+                    // Ensure IkonData has its IkonliPack set
+                    IkonData tempData = getIkonData(ikon);
+                    if (tempData != null && tempData.getIkonliPack() == null) {
+                        tempData.setIkonliPack(iconPack);
+                    }
+                }
+            }
+            return result;
+        }
+
+        // Fallback: single pack lookup via nameMap
+        IkonData ikonData = nameMap.get(iconPack.getName());
+        if (ikonData != null) {
+            IkonProvider ikonProvider = ikonData.getIkonProvider();
+            EnumSet<?> enumSet = EnumSet.allOf(ikonProvider.getIkon().asSubclass(Enum.class));
+            ObservableList<Ikon> list = FXCollections.observableArrayList();
+            for (Object icon : enumSet) {
+                list.add((Ikon) icon);
+            }
+            return list;
+        }
+
+        return FXCollections.observableArrayList();
+    }
+
+    /**
+     * Retrieves all available Ikons as an unmodifiable set.
+     */
+    public Set<Ikon> getAllIkons() {
+        if (allIkons == null) {
+            allIkons = Collections.unmodifiableSet(dataMap.keySet());
+        }
+        return allIkons;
+    }
+
+    /**
+     * Filters and retrieves icons belonging to the specified collection of IkonliPacks.
+     * Supports both original and aggregated IkonliPack instances.
+     */
+    public List<Ikon> getIkonsForPacksFiltered(Collection<IkonliPack> packs) {
+        if (packs == null || packs.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Collect all original pack names from the given packs (expanding aggregated ones)
+        Set<String> allOriginalPackNames = new java.util.HashSet<>();
+        for (IkonliPack pack : packs) {
+            String aggregatedId = getAggregatedId(pack);
+            List<IkonData> dataList = groupedByArtifact.get(aggregatedId);
+            if (dataList != null) {
+                for (IkonData data : dataList) {
+                    if (data.getIkonliPack() != null) {
+                        allOriginalPackNames.add(data.getIkonliPack().getName());
+                    }
+                }
+            } else {
+                // Fallback: treat as a direct pack name
+                allOriginalPackNames.add(pack.getName());
             }
         }
-        return list;
+
+        return dataMap.entrySet().stream()
+                .filter(entry -> {
+                    IkonData data = entry.getValue();
+                    return data.getIkonliPack() != null && allOriginalPackNames.contains(data.getIkonliPack().getName());
+                })
+                .map(Map.Entry::getKey)
+                .toList();
     }
+
+    // ==================== Icon Search ====================
+
+    /**
+     * Finds a specific Ikon by its description within a pack.
+     * Supports both original and aggregated IkonliPack instances.
+     *
+     * @param iconPack    the pack to search in
+     * @param description the description to search for
+     * @return optional containing the Ikon if found
+     */
+    public Optional<Ikon> getIkon(IkonliPack iconPack, String description) {
+        String aggregatedId = getAggregatedId(iconPack);
+        List<IkonData> dataList = groupedByArtifact.get(aggregatedId);
+
+        if (dataList != null) {
+            for (IkonData data : dataList) {
+                IkonProvider ikonProvider = data.getIkonProvider();
+                Set<?> enumSet = EnumSet.allOf(ikonProvider.getIkon().asSubclass(Enum.class));
+                for (Object icon : enumSet) {
+                    Ikon ikon = (Ikon) icon;
+                    if (StringUtils.equals(ikon.getDescription(), description)) {
+                        return Optional.of(ikon);
+                    }
+                }
+            }
+            return Optional.empty();
+        }
+
+        // Fallback: single pack lookup
+        IkonData ikonData = nameMap.get(iconPack.getName());
+        if (ikonData != null) {
+            IkonProvider ikonProvider = ikonData.getIkonProvider();
+            Set<?> enumSet = EnumSet.allOf(ikonProvider.getIkon().asSubclass(Enum.class));
+            for (Object icon : enumSet) {
+                Ikon ikon = (Ikon) icon;
+                if (StringUtils.equals(ikon.getDescription(), description)) {
+                    return Optional.of(ikon);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    // ==================== Dependency Info ====================
 
     public String getMavenDependency(Ikon ikon) {
         IkonliPack ikonliPack = getIkonData(ikon).getIkonliPack();
@@ -114,63 +422,4 @@ public class IkonliPackUtil {
 
         return ikonliPack.getInstalling().getGradle();
     }
-
-    /**
-     * Find a specific Ikon by its description.
-     *
-     * @param iconPack    the pack to search in
-     * @param description the description to search for
-     * @return optional containing the Ikon if found
-     */
-    public Optional<Ikon> getIkon(IkonliPack iconPack, String description) {
-        IkonData ikonData = getIkonData(iconPack.getName());
-        IkonProvider ikonProvider = ikonData.getIkonProvider();
-        Set<Ikon> enumSet = EnumSet.allOf(ikonProvider.getIkon());
-        for (Ikon ikon : enumSet) {
-            if (StringUtils.equals(ikon.getDescription(), description)) {
-                return Optional.of(ikon);
-            }
-        }
-        return Optional.empty();
-    }
-
-    /**
-     * Retrieves all available Ikons as an unmodifiable set. If the set has not
-     * been initialized yet, it is created from the keys of the data map and
-     * cached for future access.
-     *
-     * @return a set containing all available Ikons
-     */
-    public Set<Ikon> getAllIkons() {
-        if (allIkons == null) {
-            allIkons = Collections.unmodifiableSet(dataMap.keySet());
-        }
-        return allIkons;
-    }
-
-
-    /**
-     * Filters and retrieves a list of Ikons that belong to the specified collection of IkonliPacks.
-     *
-     * @param packs the collection of IkonliPacks to filter Ikons by; if null or empty, the method returns an empty list
-     * @return a list of Ikons associated with the specified IkonliPacks, or an empty list if no matching Ikons are found
-     */
-    public List<Ikon> getIkonsForPacksFiltered(Collection<IkonliPack> packs) {
-        if (packs == null || packs.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        Set<String> packNames = packs.stream()
-                .map(IkonliPack::getName)
-                .collect(Collectors.toSet());
-
-        return dataMap.entrySet().stream()
-                .filter(entry -> {
-                    IkonData data = entry.getValue();
-                    return data.getIkonliPack() != null && packNames.contains(data.getIkonliPack().getName());
-                })
-                .map(Map.Entry::getKey)
-                .toList();
-    }
-
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/QuickLinksGenerator.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/QuickLinksGenerator.java
@@ -237,7 +237,7 @@ public class QuickLinksGenerator {
         result.addAll(findRecentItems(repository.getRealWorldApps()));
         result.addAll(findRecentItems(repository.getDownloads()));
         result.addAll(findRecentItems(repository.getTips()));
-        result.addAll(findRecentItems(repository.getIkonliPacks()));
+        result.addAll(findRecentItems(IkonliPackUtil.getInstance().getAggregatedPacks()));
 
         // newest ones on top
         result.sort(Comparator.comparing(ModelObject::getCreationOrUpdateDate).reversed());

--- a/components/src/main/java/module-info.java
+++ b/components/src/main/java/module-info.java
@@ -44,6 +44,7 @@ open module com.dlsc.jfxcentral2.components {
     requires org.kordamp.ikonli.bootstrapicons;
     requires org.kordamp.ikonli.boxicons;
     requires org.kordamp.ikonli.bpmn;
+    requires org.kordamp.ikonli.bytedance;
     requires org.kordamp.ikonli.captainicon;
     requires org.kordamp.ikonli.carbonicons;
     requires org.kordamp.ikonli.codicons;
@@ -58,6 +59,7 @@ open module com.dlsc.jfxcentral2.components {
     requires org.kordamp.ikonli.fluentui;
     requires org.kordamp.ikonli.fontawesome;
     requires org.kordamp.ikonli.fontawesome5;
+    requires org.kordamp.ikonli.fontawesome6;
     requires org.kordamp.ikonli.fontelico;
     requires org.kordamp.ikonli.foundation;
     requires org.kordamp.ikonli.hawcons;

--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,11 @@
             </dependency>
             <dependency>
                 <groupId>org.kordamp.ikonli</groupId>
+                <artifactId>ikonli-bytedance-pack</artifactId>
+                <version>${ikonli.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kordamp.ikonli</groupId>
                 <artifactId>ikonli-captainicon-pack</artifactId>
                 <version>${ikonli.version}</version>
             </dependency>
@@ -530,6 +535,11 @@
             <dependency>
                 <groupId>org.kordamp.ikonli</groupId>
                 <artifactId>ikonli-fontawesome5-pack</artifactId>
+                <version>${ikonli.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kordamp.ikonli</groupId>
+                <artifactId>ikonli-fontawesome6-pack</artifactId>
                 <version>${ikonli.version}</version>
             </dependency>
             <dependency>

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloIkonGridView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloIkonGridView.java
@@ -1,6 +1,5 @@
 package com.dlsc.jfxcentral2.demo.components;
 
-import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
 import com.dlsc.jfxcentral2.components.gridview.IkonGridView;
 import com.dlsc.jfxcentral2.demo.JFXCentralSampleBase;
@@ -19,7 +18,7 @@ public class HelloIkonGridView extends JFXCentralSampleBase {
     @Override
     protected Region createControl() {
         ikonGridView = new IkonGridView();
-        List<Ikon> ikonList = IkonliPackUtil.getInstance().getIkonList(DataRepository.getInstance().getIkonliPacks().get(0));
+        List<Ikon> ikonList = IkonliPackUtil.getInstance().getIkonList(IkonliPackUtil.getInstance().getAggregatedPacks().get(0));
         ikonGridView.getItems().addAll(ikonList);
         return new ScrollPane(ikonGridView);
     }

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloIkonPackTileView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloIkonPackTileView.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.demo.components;
 
-import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.IkonliPack;
+import com.dlsc.jfxcentral2.utils.IkonliPackUtil;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
 import com.dlsc.jfxcentral2.components.tiles.IkonliPackTileView;
 import com.dlsc.jfxcentral2.demo.JFXCentralSampleBase;
@@ -15,7 +15,7 @@ public class HelloIkonPackTileView extends JFXCentralSampleBase {
 
     @Override
     protected Region createControl() {
-        IkonliPack ikonPackModel = DataRepository.getInstance().getIkonliPacks().get(0);
+        IkonliPack ikonPackModel = IkonliPackUtil.getInstance().getAggregatedPacks().get(0);
         ikonPackModel.setDescription("Some description");
 
         ikonPackModelTileView = new IkonliPackTileView(ikonPackModel);

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloPackGridView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloPackGridView.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.demo.components;
 
-import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.IkonliPack;
+import com.dlsc.jfxcentral2.utils.IkonliPackUtil;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
 import com.dlsc.jfxcentral2.components.gridview.ModelGridView;
 import com.dlsc.jfxcentral2.components.tiles.IkonliPackTileView;
@@ -19,7 +19,7 @@ public class HelloPackGridView extends JFXCentralSampleBase {
 
         gridView = new ModelGridView<>();
         gridView.setTileViewProvider(IkonliPackTileView::new);
-        gridView.getItems().setAll(DataRepository.getInstance().getIkonliPacks());
+        gridView.getItems().setAll(IkonliPackUtil.getInstance().getAggregatedPacks());
 
         return new ScrollPane(gridView);
     }


### PR DESCRIPTION
                                                                                                            
 ## Background                                                                                                    
                                                                                                                   
  ikonli splits large icon libraries into multiple enum classes to work around Java enum size limits (e.g.,        
  MaterialDesign2 is split into A–Z, 26 entries). Each enum has its own record in the data, resulting in 106 "icon 
  packs" on the page — many of which are just different parts of the same Maven dependency. This makes the list    
  bloated and confusing.                                                                                           
                                                                                                                   
  ## Changes                                                                                                       
                  
  Aggregate by Maven artifactId: one dependency = one display entry. Users now see 58 icon packs instead of 106.
  Also adds FontAwesome6 and Bytedance icon packs from ikonli 12.4.